### PR TITLE
Added support for save and load for a tf dataset.

### DIFF
--- a/src/sweepers/sweeper.py
+++ b/src/sweepers/sweeper.py
@@ -97,7 +97,7 @@ def main():
     '''
     train_ds, val_ds, test_ds = load_datasets(
         color_mode='rgb', target_size=(75, 75), interpolation='bilinear', keep_aspect_ratio=False,
-        train_set_size=0.6, val_set_size=0.2, test_set_size=0.2, seed=SEED, num_partitions=1, batch_size=BATCH_SIZE,
+        train_set_size=0.6, val_set_size=0.2, test_set_size=0.2, seed=SEED, num_partitions=6, batch_size=BATCH_SIZE,
         num_images=None
     )
     '''
@@ -144,7 +144,7 @@ if __name__ == '__main__':
     sweep configuration.
     """
     NUM_TRIALS = 10
-    BATCH_SIZE = 10
+    BATCH_SIZE = 16
     NUM_CLASSES = 2
     SEED = 42
     REPO_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../'))


### PR DESCRIPTION
Saves tensorflow dataset to disk so that it can be loaded in without having to repeat the downscaling process. Saves each set of unique arguments to load_datasets as `f"{color_mode}_{target_size[0]}_{target_size[1]}_{interpolation}_{keep_aspect_ratio}_{num_partitions}_{num_images}_{train_set_size}_{val_set_size_{test_set_size}_{seed}"`.

For example, the entire dataset downscaled to 75x75 using bilinear interpolation, not keeping aspect ratio, with a 60 20 20 split for train val test and a random seed of 42 is labeled as: 

```
rgb_75_75_bilinear_False_6_None_0_6_0_2_0_2_42
```

at the location `/usr/local/data/JustRAIGS/interpolated` on the lambda machine. If there is a directory with that name at the correct location, then the training program will load the saved dataset instead of building it from scratch.